### PR TITLE
Add validation logic and sample bad data

### DIFF
--- a/bad_data.json
+++ b/bad_data.json
@@ -1,0 +1,5 @@
+{
+  "name": 123,
+  "quantity": "ten",
+  "price": 5.678
+}

--- a/monitor.py
+++ b/monitor.py
@@ -1,0 +1,79 @@
+import json
+from decimal import Decimal, InvalidOperation
+
+try:
+    import requests  # make sure 'requests' is installed
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    requests = None
+
+API_URL = "https://example.com/api/endpoint"
+TEAMS_WEBHOOK = "https://outlook.office.com/webhook/your-webhook-url"
+
+def fetch_data():
+    if requests is None:
+        raise RuntimeError("The 'requests' package is required to fetch data")
+
+    response = requests.get(API_URL, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+def load_json_file(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+def _has_two_decimal_places(value):
+    try:
+        return Decimal(str(value)).as_tuple().exponent == -2
+    except (InvalidOperation, TypeError, ValueError):
+        return False
+
+def validate_data(data):
+    if not isinstance(data, dict):
+        return False
+
+    name = data.get("name")
+    quantity = data.get("quantity")
+    price = data.get("price")
+
+    if not isinstance(name, str):
+        return False
+    if not isinstance(quantity, int):
+        return False
+    if not isinstance(price, (float, int, str)) or not _has_two_decimal_places(price):
+        return False
+
+    return True
+
+def send_teams_message(message):
+    if requests is None:
+        print(f"[Teams message not sent] {message}")
+        return
+
+    payload = {"text": message}
+    requests.post(TEAMS_WEBHOOK, json=payload)
+
+def monitor(filepath=None):
+    try:
+        if filepath:
+            data = load_json_file(filepath)
+        else:
+            data = fetch_data()
+    except Exception as e:
+        send_teams_message(f"API call failed: {e}")
+        return
+
+    if not validate_data(data):
+        send_teams_message("Warning: data validation failed")
+    else:
+        print("Data looks good")
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Validate API or file data")
+    parser.add_argument(
+        "--file", dest="file", help="Path to JSON file containing test data"
+    )
+    args = parser.parse_args()
+
+    monitor(args.file)


### PR DESCRIPTION
## Summary
- improve monitor to validate `name`, `quantity`, and `price`
- allow loading JSON data from a file
- add `bad_data.json` demonstrating invalid payload

## Testing
- `pytest -q`
- `python monitor.py --file bad_data.json`

------
https://chatgpt.com/codex/tasks/task_b_686447a5230c8320931202bb471f0046