### PR TITLE
Add --api-url argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,11 @@ data from an API or load a JSON file for testing.
 python monitor.py --file bad_data.json
 ```
 
+Override the default API endpoint with `--api-url`:
+
+```bash
+python monitor.py --api-url https://api.example.com/data
+```
+
 If validation fails, an adaptive card is sent to Teams via the configured
 webhook.

--- a/monitor.py
+++ b/monitor.py
@@ -13,11 +13,11 @@ TEAMS_WEBHOOK = (
     "&sv=1.0&sig=CeyLTWbKgyRWRigW3k4fVWAPBOkk_WAqPFKpve4MC88"
 )
 
-def fetch_data():
+def fetch_data(api_url=API_URL):
     if requests is None:
         raise RuntimeError("The 'requests' package is required to fetch data")
 
-    response = requests.get(API_URL, timeout=10)
+    response = requests.get(api_url, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -77,12 +77,12 @@ def send_teams_message(message):
     }
     requests.post(TEAMS_WEBHOOK, json=payload)
 
-def monitor(filepath=None):
+def monitor(filepath=None, api_url=API_URL):
     try:
         if filepath:
             data = load_json_file(filepath)
         else:
-            data = fetch_data()
+            data = fetch_data(api_url)
     except Exception as e:
         send_teams_message(f"API call failed: {e}")
         return
@@ -99,6 +99,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "--file", dest="file", help="Path to JSON file containing test data"
     )
+    parser.add_argument(
+        "--api-url",
+        dest="api_url",
+        help="API endpoint URL. Defaults to API_URL constant if omitted",
+    )
     args = parser.parse_args()
 
-    monitor(args.file)
+    monitor(args.file, api_url=args.api_url or API_URL)


### PR DESCRIPTION
## Summary
- allow overriding the API endpoint with `--api-url`
- document the new CLI option

## Testing
- `python -m py_compile monitor.py`
- `python monitor.py --help | head`


------
https://chatgpt.com/codex/tasks/task_b_686457ee45408320a3acd931f51df466