### PR TITLE
Add API URL option and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,13 @@ python monitor.py --file bad_data.json
 
 If validation fails, an adaptive card is sent to Teams via the configured
 webhook.
+
+## Using a real API
+
+Pass the API endpoint with `--url` to test live data. Any JSON API will do,
+including public services like [jsonplaceholder.typicode.com](https://jsonplaceholder.typicode.com)
+or your own mock endpoints.
+
+```bash
+python monitor.py --url https://jsonplaceholder.typicode.com/todos/1
+```

--- a/monitor.py
+++ b/monitor.py
@@ -13,11 +13,11 @@ TEAMS_WEBHOOK = (
     "&sv=1.0&sig=CeyLTWbKgyRWRigW3k4fVWAPBOkk_WAqPFKpve4MC88"
 )
 
-def fetch_data():
+def fetch_data(url=API_URL):
     if requests is None:
         raise RuntimeError("The 'requests' package is required to fetch data")
 
-    response = requests.get(API_URL, timeout=10)
+    response = requests.get(url, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -77,12 +77,12 @@ def send_teams_message(message):
     }
     requests.post(TEAMS_WEBHOOK, json=payload)
 
-def monitor(filepath=None):
+def monitor(filepath=None, api_url=API_URL):
     try:
         if filepath:
             data = load_json_file(filepath)
         else:
-            data = fetch_data()
+            data = fetch_data(api_url)
     except Exception as e:
         send_teams_message(f"API call failed: {e}")
         return
@@ -99,6 +99,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--file", dest="file", help="Path to JSON file containing test data"
     )
+    parser.add_argument(
+        "--url",
+        dest="url",
+        default=API_URL,
+        help="API endpoint to fetch data from",
+    )
     args = parser.parse_args()
 
-    monitor(args.file)
+    monitor(args.file, args.url)


### PR DESCRIPTION
## Summary
- allow specifying a custom API URL via `--url`
- document how to use the new argument in README

## Testing
- `python monitor.py --help`
- `python monitor.py --file bad_data.json`


------
https://chatgpt.com/codex/tasks/task_b_686457ef646883208f9a6b07444517c2